### PR TITLE
feat(telegram): interactive two-step alert creation with unit tests

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -87,3 +87,5 @@ npm run dev
 ```
 
 See the respective `AGENTS.md` files in each directory for complete command references and style guidelines.
+
+Always use Context7 MCP when I need library/API documentation, code generation, setup or configuration steps without me having to explicitly ask.

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -87,5 +87,3 @@ npm run dev
 ```
 
 See the respective `AGENTS.md` files in each directory for complete command references and style guidelines.
-
-Always use Context7 MCP when generating code that involves external libraries or frameworks, without me having to ask.

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -87,3 +87,5 @@ npm run dev
 ```
 
 See the respective `AGENTS.md` files in each directory for complete command references and style guidelines.
+
+Always use Context7 MCP when generating code that involves external libraries or frameworks, without me having to ask.

--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,9 @@ backend/*.DotSettings.user
 .cursor/mcp.json
 .cursor/skills/
 .github/agents/skills
+.github/copilot-instructions.md
+.mcp.json
+.vscode/mcp.json
 AGENTS.md
 CLAUDE.md
 # END AI Agent Symlinks

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -168,3 +168,5 @@ dotnet run --project Apps/Api
 # Apply EF migrations
 dotnet ef database update --project WallapopNotification
 ```
+
+Always use Context7 MCP when generating code that involves external libraries or frameworks, without me having to ask.

--- a/backend/api/Extension/DependencyInjection/Application.cs
+++ b/backend/api/Extension/DependencyInjection/Application.cs
@@ -16,6 +16,7 @@ public static class Application
 
         services.AddScoped<ItemSearcher>();
         services.AddScoped<TelegramBotConnection>();
+        services.AddScoped<ITelegramBotConnection>(sp => sp.GetRequiredService<TelegramBotConnection>());
         services.AddScoped<TelegramBot>();
         services.AddScoped<OnMessageHandlerFactory>();
         services.AddScoped<OnUpdateHandlerFactory>();

--- a/backend/api/Extension/DependencyInjection/Application.cs
+++ b/backend/api/Extension/DependencyInjection/Application.cs
@@ -1,4 +1,5 @@
 using Wallanoti.Api.Telegram.Configurations;
+using Wallanoti.Api.Telegram.Conversation;
 using Wallanoti.Api.Telegram.Handlers;
 using Wallanoti.Api.Telegram.Handlers.MessageResolver;
 using Wallanoti.Src.Alerts.Application.SearchNewItems;
@@ -21,6 +22,9 @@ public static class Application
         services.AddScoped<StartTelegramMessageResolver>();
         services.AddScoped<NewAlertTelegramMessageResolver>();
         services.AddScoped<ListTelegramMessageResolver>();
+        services.AddScoped<AlertUrlTelegramMessageResolver>();
+        services.AddScoped<CancelTelegramMessageResolver>();
+        services.AddScoped<ITelegramConversationRepository, RedisTelegramConversationRepository>();
 
         return services;
     }

--- a/backend/api/Telegram/Configurations/TelegramBot.cs
+++ b/backend/api/Telegram/Configurations/TelegramBot.cs
@@ -24,7 +24,7 @@ public sealed class TelegramBot : IAsyncDisposable
 
     public async Task Start()
     {
-        var botClient = _telegramBotConnection.Client();
+        var botClient = (TelegramBotClient)_telegramBotConnection.Client();
 
         await Prepare();
 
@@ -71,7 +71,7 @@ public sealed class TelegramBot : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
-        var botClient = _telegramBotConnection.Client();
+        var botClient = (TelegramBotClient)_telegramBotConnection.Client();
 
         await botClient.Close();
     }

--- a/backend/api/Telegram/Configurations/TelegramBot.cs
+++ b/backend/api/Telegram/Configurations/TelegramBot.cs
@@ -39,9 +39,7 @@ public sealed class TelegramBot : IAsyncDisposable
 
     private async Task OnMessage(Message message, UpdateType type)
     {
-        var command = message.Text?.ToLower().Split(",").FirstOrDefault();
-
-        var resolver = _onMessageHandlerFactory.Handle(command);
+        var resolver = await _onMessageHandlerFactory.HandleAsync(message.Chat.Id, message.Text);
 
         await resolver.Execute(message);
     }
@@ -53,8 +51,10 @@ public sealed class TelegramBot : IAsyncDisposable
         var commands = await botClient.GetMyCommands();
 
         if (commands.Any(x =>
-                x.Command is StartTelegramMessageResolver.Command or NewAlertTelegramMessageResolver.Command
-                    or ListTelegramMessageResolver.Command))
+                x.Command is StartTelegramMessageResolver.Command
+                    or NewAlertTelegramMessageResolver.Command
+                    or ListTelegramMessageResolver.Command
+                    or CancelTelegramMessageResolver.Command))
         {
             return;
         }
@@ -65,6 +65,7 @@ public sealed class TelegramBot : IAsyncDisposable
         {
             new() { Command = NewAlertTelegramMessageResolver.Command, Description = "Crea una nueva alerta" },
             new() { Command = ListTelegramMessageResolver.Command, Description = "Lista las alertas" },
+            new() { Command = CancelTelegramMessageResolver.Command, Description = "Cancela la operación en curso" },
         });
     }
 

--- a/backend/api/Telegram/Conversation/ConversationState.cs
+++ b/backend/api/Telegram/Conversation/ConversationState.cs
@@ -1,0 +1,3 @@
+namespace Wallanoti.Api.Telegram.Conversation;
+
+public enum ConversationState { Idle, AwaitingUrl }

--- a/backend/api/Telegram/Conversation/ITelegramConversationRepository.cs
+++ b/backend/api/Telegram/Conversation/ITelegramConversationRepository.cs
@@ -1,0 +1,8 @@
+namespace Wallanoti.Api.Telegram.Conversation;
+
+public interface ITelegramConversationRepository
+{
+    Task<ConversationState> GetStateAsync(long chatId);
+    Task SetStateAsync(long chatId, ConversationState state);
+    Task ClearAsync(long chatId);
+}

--- a/backend/api/Telegram/Conversation/RedisTelegramConversationRepository.cs
+++ b/backend/api/Telegram/Conversation/RedisTelegramConversationRepository.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace Wallanoti.Api.Telegram.Conversation;
+
+public sealed class RedisTelegramConversationRepository : ITelegramConversationRepository
+{
+    private readonly IDistributedCache _cache;
+    private static readonly TimeSpan Ttl = TimeSpan.FromMinutes(10);
+
+    public RedisTelegramConversationRepository(IDistributedCache cache)
+    {
+        _cache = cache;
+    }
+
+    public async Task<ConversationState> GetStateAsync(long chatId)
+    {
+        var value = await _cache.GetStringAsync(Key(chatId));
+
+        if (value is null)
+            return ConversationState.Idle;
+
+        return Enum.TryParse<ConversationState>(value, out var state)
+            ? state
+            : ConversationState.Idle;
+    }
+
+    public Task SetStateAsync(long chatId, ConversationState state)
+    {
+        return _cache.SetStringAsync(Key(chatId), state.ToString(), new DistributedCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = Ttl
+        });
+    }
+
+    public Task ClearAsync(long chatId)
+    {
+        return _cache.RemoveAsync(Key(chatId));
+    }
+
+    private static string Key(long chatId) => $"telegram:conv:{chatId}";
+}

--- a/backend/api/Telegram/Handlers/MessageResolver/AlertUrlTelegramMessageResolver.cs
+++ b/backend/api/Telegram/Handlers/MessageResolver/AlertUrlTelegramMessageResolver.cs
@@ -1,0 +1,67 @@
+using MediatR;
+using Telegram.Bot;
+using Telegram.Bot.Types;
+using Wallanoti.Api.Telegram.Conversation;
+using Wallanoti.Src.Alerts.Application.CreateAlert;
+using Wallanoti.Src.Notifications.Infrastructure.Telegram;
+
+namespace Wallanoti.Api.Telegram.Handlers.MessageResolver;
+
+public sealed class AlertUrlTelegramMessageResolver : IMessageResolver
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly TelegramBotConnection _botConnection;
+    private readonly ITelegramConversationRepository _conversationRepository;
+
+    public AlertUrlTelegramMessageResolver(
+        IServiceScopeFactory scopeFactory,
+        TelegramBotConnection botConnection,
+        ITelegramConversationRepository conversationRepository)
+    {
+        _scopeFactory = scopeFactory;
+        _botConnection = botConnection;
+        _conversationRepository = conversationRepository;
+    }
+
+    public async Task Execute(Message message)
+    {
+        var chatId = message.Chat.Id;
+        var text = message.Text ?? string.Empty;
+
+        if (!text.Contains("https://es.wallapop.com"))
+        {
+            await _botConnection.Client().SendMessage(chatId,
+                "La URL debe ser de Wallapop (es.wallapop.com). Por favor, envíame la URL de búsqueda correcta.");
+            return;
+        }
+
+        if (!Uri.TryCreate(text, UriKind.Absolute, out var uri))
+        {
+            await _botConnection.Client().SendMessage(chatId,
+                "La URL no es válida. Por favor, copia la URL directamente desde Wallapop.");
+            return;
+        }
+
+        var queryParams = System.Web.HttpUtility.ParseQueryString(uri.Query);
+        var rawKeywords = queryParams["keywords"];
+
+        if (string.IsNullOrWhiteSpace(rawKeywords))
+        {
+            await _botConnection.Client().SendMessage(chatId,
+                "La URL no contiene el parámetro de búsqueda (keywords). Asegúrate de buscar algo en Wallapop y copiar la URL de los resultados.");
+            return;
+        }
+
+        var alertName = Uri.UnescapeDataString(rawKeywords.Replace("+", " "));
+
+        using var scope = _scopeFactory.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        await mediator.Send(new CreateAlertCommand(chatId, alertName, text));
+
+        await _conversationRepository.ClearAsync(chatId);
+
+        await _botConnection.Client().SendMessage(chatId,
+            $"Alerta \"{alertName}\" creada ✅");
+    }
+}

--- a/backend/api/Telegram/Handlers/MessageResolver/AlertUrlTelegramMessageResolver.cs
+++ b/backend/api/Telegram/Handlers/MessageResolver/AlertUrlTelegramMessageResolver.cs
@@ -28,17 +28,18 @@ public sealed class AlertUrlTelegramMessageResolver : IMessageResolver
         var chatId = message.Chat.Id;
         var text = message.Text ?? string.Empty;
 
-        if (!text.Contains("https://es.wallapop.com"))
-        {
-            await _botConnection.Client().SendMessage(chatId,
-                "La URL debe ser de Wallapop (es.wallapop.com). Por favor, envíame la URL de búsqueda correcta.");
-            return;
-        }
-
         if (!Uri.TryCreate(text, UriKind.Absolute, out var uri))
         {
             await _botConnection.Client().SendMessage(chatId,
                 "La URL no es válida. Por favor, copia la URL directamente desde Wallapop.");
+            return;
+        }
+
+        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, System.StringComparison.OrdinalIgnoreCase) ||
+            !string.Equals(uri.Host, "es.wallapop.com", System.StringComparison.OrdinalIgnoreCase))
+        {
+            await _botConnection.Client().SendMessage(chatId,
+                "La URL debe ser de Wallapop (es.wallapop.com). Por favor, envíame la URL de búsqueda correcta.");
             return;
         }
 

--- a/backend/api/Telegram/Handlers/MessageResolver/AlertUrlTelegramMessageResolver.cs
+++ b/backend/api/Telegram/Handlers/MessageResolver/AlertUrlTelegramMessageResolver.cs
@@ -10,12 +10,12 @@ namespace Wallanoti.Api.Telegram.Handlers.MessageResolver;
 public sealed class AlertUrlTelegramMessageResolver : IMessageResolver
 {
     private readonly IServiceScopeFactory _scopeFactory;
-    private readonly TelegramBotConnection _botConnection;
+    private readonly ITelegramBotConnection _botConnection;
     private readonly ITelegramConversationRepository _conversationRepository;
 
     public AlertUrlTelegramMessageResolver(
         IServiceScopeFactory scopeFactory,
-        TelegramBotConnection botConnection,
+        ITelegramBotConnection botConnection,
         ITelegramConversationRepository conversationRepository)
     {
         _scopeFactory = scopeFactory;

--- a/backend/api/Telegram/Handlers/MessageResolver/CancelTelegramMessageResolver.cs
+++ b/backend/api/Telegram/Handlers/MessageResolver/CancelTelegramMessageResolver.cs
@@ -5,14 +5,14 @@ using Wallanoti.Src.Notifications.Infrastructure.Telegram;
 
 namespace Wallanoti.Api.Telegram.Handlers.MessageResolver;
 
-public sealed class NewAlertTelegramMessageResolver : IMessageResolver
+public sealed class CancelTelegramMessageResolver : IMessageResolver
 {
-    public const string Command = "/alert";
+    public const string Command = "/cancel";
 
     private readonly TelegramBotConnection _botConnection;
     private readonly ITelegramConversationRepository _conversationRepository;
 
-    public NewAlertTelegramMessageResolver(
+    public CancelTelegramMessageResolver(
         TelegramBotConnection botConnection,
         ITelegramConversationRepository conversationRepository)
     {
@@ -23,10 +23,18 @@ public sealed class NewAlertTelegramMessageResolver : IMessageResolver
     public async Task Execute(Message message)
     {
         var chatId = message.Chat.Id;
+        var state = await _conversationRepository.GetStateAsync(chatId);
 
-        await _conversationRepository.SetStateAsync(chatId, ConversationState.AwaitingUrl);
+        if (state == ConversationState.Idle)
+        {
+            await _botConnection.Client().SendMessage(chatId,
+                "No tienes ninguna operación en curso.");
+            return;
+        }
+
+        await _conversationRepository.ClearAsync(chatId);
 
         await _botConnection.Client().SendMessage(chatId,
-            "Envíame la URL de búsqueda de Wallapop 🔗");
+            "Operación cancelada ✅");
     }
 }

--- a/backend/api/Telegram/Handlers/MessageResolver/CancelTelegramMessageResolver.cs
+++ b/backend/api/Telegram/Handlers/MessageResolver/CancelTelegramMessageResolver.cs
@@ -9,11 +9,11 @@ public sealed class CancelTelegramMessageResolver : IMessageResolver
 {
     public const string Command = "/cancel";
 
-    private readonly TelegramBotConnection _botConnection;
+    private readonly ITelegramBotConnection _botConnection;
     private readonly ITelegramConversationRepository _conversationRepository;
 
     public CancelTelegramMessageResolver(
-        TelegramBotConnection botConnection,
+        ITelegramBotConnection botConnection,
         ITelegramConversationRepository conversationRepository)
     {
         _botConnection = botConnection;

--- a/backend/api/Telegram/Handlers/MessageResolver/ListTelegramMessageResolver.cs
+++ b/backend/api/Telegram/Handlers/MessageResolver/ListTelegramMessageResolver.cs
@@ -12,9 +12,9 @@ public sealed class ListTelegramMessageResolver : IMessageResolver
     public const string Command = "/list";
 
     private readonly IServiceScopeFactory _scopeFactory;
-    private readonly TelegramBotConnection _botConnection;
+    private readonly ITelegramBotConnection _botConnection;
 
-    public ListTelegramMessageResolver(IServiceScopeFactory scopeFactory, TelegramBotConnection botConnection)
+    public ListTelegramMessageResolver(IServiceScopeFactory scopeFactory, ITelegramBotConnection botConnection)
     {
         _scopeFactory = scopeFactory;
         _botConnection = botConnection;

--- a/backend/api/Telegram/Handlers/MessageResolver/NewAlertTelegramMessageResolver.cs
+++ b/backend/api/Telegram/Handlers/MessageResolver/NewAlertTelegramMessageResolver.cs
@@ -9,11 +9,11 @@ public sealed class NewAlertTelegramMessageResolver : IMessageResolver
 {
     public const string Command = "/alert";
 
-    private readonly TelegramBotConnection _botConnection;
+    private readonly ITelegramBotConnection _botConnection;
     private readonly ITelegramConversationRepository _conversationRepository;
 
     public NewAlertTelegramMessageResolver(
-        TelegramBotConnection botConnection,
+        ITelegramBotConnection botConnection,
         ITelegramConversationRepository conversationRepository)
     {
         _botConnection = botConnection;

--- a/backend/api/Telegram/Handlers/MessageResolver/StartTelegramMessageResolver.cs
+++ b/backend/api/Telegram/Handlers/MessageResolver/StartTelegramMessageResolver.cs
@@ -10,9 +10,9 @@ public sealed class StartTelegramMessageResolver : IMessageResolver
 {
     public const string Command = "/start";
     private readonly IServiceScopeFactory _scopeFactory;
-    private readonly TelegramBotConnection _botConnection;
+    private readonly ITelegramBotConnection _botConnection;
 
-    public StartTelegramMessageResolver(IServiceScopeFactory scopeFactory, TelegramBotConnection botConnection)
+    public StartTelegramMessageResolver(IServiceScopeFactory scopeFactory, ITelegramBotConnection botConnection)
     {
         _scopeFactory = scopeFactory;
         _botConnection = botConnection;

--- a/backend/api/Telegram/Handlers/MessageResolver/StartTelegramMessageResolver.cs
+++ b/backend/api/Telegram/Handlers/MessageResolver/StartTelegramMessageResolver.cs
@@ -30,6 +30,6 @@ public sealed class StartTelegramMessageResolver : IMessageResolver
         await mediator.Send(new CreateUserCommand(message.Chat.Id, message.Chat.Username));
 
         await _botConnection.Client().SendMessage(message.Chat.Id,
-            "Ya puedes crear alertas con el comando /alert. Ejemplo: /alert, Televisor LG 55 pulgadas, https://es.wallapop.com/item/televisor-lg-55-pulgadas-123456789");
+            "Ya puedes crear alertas con el comando /alert. Simplemente escribe /alert y te pediré la URL de búsqueda de Wallapop 🔗");
     }
 }

--- a/backend/api/Telegram/Handlers/OnMessageHandlerFactory.cs
+++ b/backend/api/Telegram/Handlers/OnMessageHandlerFactory.cs
@@ -1,3 +1,4 @@
+using Wallanoti.Api.Telegram.Conversation;
 using Wallanoti.Api.Telegram.Handlers.MessageResolver;
 
 namespace Wallanoti.Api.Telegram.Handlers;
@@ -7,19 +8,49 @@ public sealed class OnMessageHandlerFactory
     private readonly StartTelegramMessageResolver _startTelegramMessageResolver;
     private readonly NewAlertTelegramMessageResolver _newAlertTelegramMessageResolver;
     private readonly ListTelegramMessageResolver _listTelegramMessageResolver;
+    private readonly AlertUrlTelegramMessageResolver _alertUrlTelegramMessageResolver;
+    private readonly CancelTelegramMessageResolver _cancelTelegramMessageResolver;
+    private readonly ITelegramConversationRepository _conversationRepository;
 
-    public OnMessageHandlerFactory(StartTelegramMessageResolver startTelegramMessageResolver,
+    public OnMessageHandlerFactory(
+        StartTelegramMessageResolver startTelegramMessageResolver,
         NewAlertTelegramMessageResolver newAlertTelegramMessageResolver,
-        ListTelegramMessageResolver listTelegramMessageResolver)
+        ListTelegramMessageResolver listTelegramMessageResolver,
+        AlertUrlTelegramMessageResolver alertUrlTelegramMessageResolver,
+        CancelTelegramMessageResolver cancelTelegramMessageResolver,
+        ITelegramConversationRepository conversationRepository)
     {
         _startTelegramMessageResolver = startTelegramMessageResolver;
         _newAlertTelegramMessageResolver = newAlertTelegramMessageResolver;
         _listTelegramMessageResolver = listTelegramMessageResolver;
+        _alertUrlTelegramMessageResolver = alertUrlTelegramMessageResolver;
+        _cancelTelegramMessageResolver = cancelTelegramMessageResolver;
+        _conversationRepository = conversationRepository;
     }
 
-    public IMessageResolver Handle(string? command)
+    public async Task<IMessageResolver> HandleAsync(long chatId, string? messageText)
     {
-        return command switch
+        // Determine the command token: first word if starts with "/", else null
+        var token = messageText?.Trim();
+        var isCommand = token?.StartsWith("/") == true;
+        var commandToken = isCommand ? token?.Split(' ').FirstOrDefault()?.ToLower() : null;
+
+        // /cancel is always handled first regardless of state
+        if (commandToken == CancelTelegramMessageResolver.Command)
+            return _cancelTelegramMessageResolver;
+
+        // If not a command, check conversation state for free-text routing
+        if (!isCommand)
+        {
+            var state = await _conversationRepository.GetStateAsync(chatId);
+            if (state == ConversationState.AwaitingUrl)
+                return _alertUrlTelegramMessageResolver;
+
+            return _startTelegramMessageResolver;
+        }
+
+        // Command routing
+        return commandToken switch
         {
             NewAlertTelegramMessageResolver.Command => _newAlertTelegramMessageResolver,
             ListTelegramMessageResolver.Command => _listTelegramMessageResolver,

--- a/backend/api/Telegram/Handlers/OnMessageHandlerFactory.cs
+++ b/backend/api/Telegram/Handlers/OnMessageHandlerFactory.cs
@@ -33,8 +33,24 @@ public sealed class OnMessageHandlerFactory
         // Determine the command token: first word if starts with "/", else null
         var token = messageText?.Trim();
         var isCommand = token?.StartsWith("/") == true;
-        var commandToken = isCommand ? token?.Split(' ').FirstOrDefault()?.ToLower() : null;
+        string? commandToken = null;
+        if (isCommand && token is not null)
+        {
+            // Take the first whitespace-delimited token (e.g. "/alert@MyBot")
+            commandToken = token.Split(' ').FirstOrDefault();
 
+            if (!string.IsNullOrEmpty(commandToken))
+            {
+                // Normalize Telegram group-chat commands like "/command@BotName" to "/command"
+                var atIndex = commandToken.IndexOf('@');
+                if (atIndex > 0)
+                {
+                    commandToken = commandToken.Substring(0, atIndex);
+                }
+
+                commandToken = commandToken.ToLower();
+            }
+        }
         // /cancel is always handled first regardless of state
         if (commandToken == CancelTelegramMessageResolver.Command)
             return _cancelTelegramMessageResolver;

--- a/backend/src/Notifications/Infrastructure/Notifications/TelegramPushNotificationSender.cs
+++ b/backend/src/Notifications/Infrastructure/Notifications/TelegramPushNotificationSender.cs
@@ -1,4 +1,5 @@
 using Telegram.Bot;
+using Telegram.Bot.Exceptions;
 using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
 using Wallanoti.Src.Notifications.Domain;
@@ -8,6 +9,9 @@ namespace Wallanoti.Src.Notifications.Infrastructure.Notifications;
 
 public class TelegramPushNotificationSender : IPushNotificationSender
 {
+    private const int MaxTooManyRequestsRetries = 3;
+    private static readonly TimeSpan MaxRetryDelay = TimeSpan.FromSeconds(30);
+
     private readonly ITelegramBotConnection _telegramConnection;
 
     public TelegramPushNotificationSender(ITelegramBotConnection telegramBotConnection)
@@ -24,7 +28,12 @@ public class TelegramPushNotificationSender : IPushNotificationSender
 
         if (notification.Images == null || notification.Images.Count == 0)
         {
-            await botClient.SendMessage(notification.UserId, notification.FormattedString(), ParseMode.Html);
+            await SendMessageWithRetry(
+                botClient,
+                notification.UserId,
+                notification.FormattedString(),
+                ParseMode.Html,
+                CancellationToken.None);
             return;
         }
 
@@ -36,12 +45,86 @@ public class TelegramPushNotificationSender : IPushNotificationSender
         });
         images.AddRange(notification.Images.Skip(1).Select(imageUrl => new InputMediaPhoto(imageUrl)));
 
-        await botClient.SendMediaGroup(notification.UserId, images);
+        await SendMediaGroupWithRetry(botClient, notification.UserId, images, CancellationToken.None);
     }
 
     public Task Notify(long userId, string message)
     {
         var botClient = _telegramConnection.Client();
-        return botClient.SendMessage(userId, message);
+
+        return SendMessageWithRetry(
+            botClient,
+            userId,
+            message,
+            null,
+            CancellationToken.None);
+    }
+
+    private static Task SendMessageWithRetry(
+        ITelegramBotClient botClient,
+        long userId,
+        string message,
+        ParseMode? parseMode,
+        CancellationToken cancellationToken)
+    {
+        return ExecuteWithRetry(
+            ct => parseMode.HasValue
+                ? botClient.SendMessage(userId, message, parseMode: parseMode.Value, cancellationToken: ct)
+                : botClient.SendMessage(userId, message, cancellationToken: ct),
+            cancellationToken);
+    }
+
+    private static async Task SendMediaGroupWithRetry(
+        ITelegramBotClient botClient,
+        long userId,
+        IEnumerable<IAlbumInputMedia> images,
+        CancellationToken cancellationToken)
+    {
+        await ExecuteWithRetry(
+            ct => botClient.SendMediaGroup(userId, images, cancellationToken: ct),
+            cancellationToken);
+    }
+
+    private static async Task ExecuteWithRetry(
+        Func<CancellationToken, Task> action,
+        CancellationToken cancellationToken)
+    {
+        var retryCount = 0;
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                await action(cancellationToken);
+                return;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (ApiRequestException exception) when (ShouldRetry(exception, retryCount))
+            {
+                retryCount++;
+                var retryDelay = GetRetryDelay(exception);
+                await Task.Delay(retryDelay, cancellationToken);
+            }
+        }
+    }
+
+    private static bool ShouldRetry(ApiRequestException exception, int retryCount)
+    {
+        return exception.ErrorCode == 429 && retryCount < MaxTooManyRequestsRetries;
+    }
+
+    private static TimeSpan GetRetryDelay(ApiRequestException exception)
+    {
+        var retryAfter = exception.Parameters?.RetryAfter;
+
+        if (retryAfter is not > 0)
+            return TimeSpan.Zero;
+
+        return TimeSpan.FromSeconds(Math.Min(retryAfter.Value, MaxRetryDelay.TotalSeconds));
     }
 }

--- a/backend/src/Notifications/Infrastructure/Notifications/TelegramPushNotificationSender.cs
+++ b/backend/src/Notifications/Infrastructure/Notifications/TelegramPushNotificationSender.cs
@@ -8,9 +8,9 @@ namespace Wallanoti.Src.Notifications.Infrastructure.Notifications;
 
 public class TelegramPushNotificationSender : IPushNotificationSender
 {
-    private readonly TelegramBotConnection _telegramConnection;
+    private readonly ITelegramBotConnection _telegramConnection;
 
-    public TelegramPushNotificationSender(TelegramBotConnection telegramBotConnection)
+    public TelegramPushNotificationSender(ITelegramBotConnection telegramBotConnection)
     {
         _telegramConnection = telegramBotConnection;
     }

--- a/backend/src/Notifications/Infrastructure/Telegram/ITelegramBotConnection.cs
+++ b/backend/src/Notifications/Infrastructure/Telegram/ITelegramBotConnection.cs
@@ -1,0 +1,8 @@
+using Telegram.Bot;
+
+namespace Wallanoti.Src.Notifications.Infrastructure.Telegram;
+
+public interface ITelegramBotConnection
+{
+    ITelegramBotClient Client();
+}

--- a/backend/src/Notifications/Infrastructure/Telegram/TelegramBotConnection.cs
+++ b/backend/src/Notifications/Infrastructure/Telegram/TelegramBotConnection.cs
@@ -3,7 +3,7 @@ using Telegram.Bot;
 
 namespace Wallanoti.Src.Notifications.Infrastructure.Telegram;
 
-public sealed class TelegramBotConnection
+public sealed class TelegramBotConnection : ITelegramBotConnection
 {
     private static TelegramBotClient? BotClient { get; set; }
     private readonly string _token;
@@ -13,7 +13,7 @@ public sealed class TelegramBotConnection
         _token = configuration.GetValue<string>("TelegramBotToken");
     }
 
-    public TelegramBotClient Client()
+    public ITelegramBotClient Client()
     {
         var options = new TelegramBotClientOptions(_token) { RetryThreshold = 120, RetryCount = 2 };
         return BotClient ??= new TelegramBotClient(options);

--- a/backend/tests/Notifications/3-Infrastructure/Notifications/TelegramPushNotificationSenderTest.cs
+++ b/backend/tests/Notifications/3-Infrastructure/Notifications/TelegramPushNotificationSenderTest.cs
@@ -1,0 +1,117 @@
+using Moq;
+using Telegram.Bot;
+using Telegram.Bot.Exceptions;
+using Telegram.Bot.Requests;
+using Telegram.Bot.Types;
+using Wallanoti.Src.Notifications.Domain;
+using Wallanoti.Src.Notifications.Infrastructure.Notifications;
+using Wallanoti.Src.Notifications.Infrastructure.Telegram;
+using Wallanoti.Src.Shared.Domain.ValueObjects;
+
+namespace Wallanoti.Tests.Notifications._3_Infrastructure.Notifications;
+
+public class TelegramPushNotificationSenderTest
+{
+    private readonly Mock<ITelegramBotClient> _botClientMock = new();
+    private readonly Mock<ITelegramBotConnection> _botConnectionMock = new();
+
+    public TelegramPushNotificationSenderTest()
+    {
+        _botConnectionMock.Setup(x => x.Client()).Returns(_botClientMock.Object);
+    }
+
+    [Fact]
+    public async Task Notify_WhenMediaGroupGets429_RetriesAndSucceeds()
+    {
+        var sender = new TelegramPushNotificationSender(_botConnectionMock.Object);
+        var notification = BuildNotification(new List<string> { "https://image-1", "https://image-2" });
+
+        _botClientMock
+            .SetupSequence(x => x.SendRequest(It.IsAny<SendMediaGroupRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ApiRequestException(
+                "Too Many Requests: retry after 1",
+                429,
+                new ResponseParameters { RetryAfter = 1 }))
+            .ReturnsAsync(new[] { new Message() });
+
+        await sender.Notify(notification);
+
+        _botClientMock.Verify(
+            x => x.SendRequest(It.IsAny<SendMediaGroupRequest>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task Notify_WhenMediaGroupGets429Repeatedly_ThrowsAfterFiniteRetries()
+    {
+        var sender = new TelegramPushNotificationSender(_botConnectionMock.Object);
+        var notification = BuildNotification(new List<string> { "https://image-1", "https://image-2" });
+
+        _botClientMock
+            .Setup(x => x.SendRequest(It.IsAny<SendMediaGroupRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ApiRequestException(
+                "Too Many Requests: retry after 1",
+                429,
+                new ResponseParameters { RetryAfter = 1 }));
+
+        await Assert.ThrowsAsync<ApiRequestException>(() => sender.Notify(notification));
+
+        _botClientMock.Verify(
+            x => x.SendRequest(It.IsAny<SendMediaGroupRequest>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(4));
+    }
+
+    [Fact]
+    public async Task Notify_WhenPlainMessageGets429_RetriesAndSucceeds()
+    {
+        var sender = new TelegramPushNotificationSender(_botConnectionMock.Object);
+        var notification = BuildNotification(Array.Empty<string>());
+
+        _botClientMock
+            .SetupSequence(x => x.SendRequest(It.IsAny<SendMessageRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ApiRequestException(
+                "Too Many Requests: retry after 1",
+                429,
+                new ResponseParameters { RetryAfter = 1 }))
+            .ReturnsAsync(new Message());
+
+        await sender.Notify(notification);
+
+        _botClientMock.Verify(
+            x => x.SendRequest(It.IsAny<SendMessageRequest>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task NotifyByUserId_WhenPlainMessageGets429Repeatedly_ThrowsAfterFiniteRetries()
+    {
+        var sender = new TelegramPushNotificationSender(_botConnectionMock.Object);
+
+        _botClientMock
+            .Setup(x => x.SendRequest(It.IsAny<SendMessageRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ApiRequestException(
+                "Too Many Requests: retry after 1",
+                429,
+                new ResponseParameters { RetryAfter = 1 }));
+
+        await Assert.ThrowsAsync<ApiRequestException>(() => sender.Notify(123, "test message"));
+
+        _botClientMock.Verify(
+            x => x.SendRequest(It.IsAny<SendMessageRequest>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(4));
+    }
+
+    private static Notification BuildNotification(IReadOnlyList<string> images)
+    {
+        return Notification.Create(
+            Guid.NewGuid(),
+            123,
+            "title",
+            "description",
+            Price.Create(10, 12),
+            images.ToList(),
+            "city",
+            Url.CreateFromSlug("slug")
+        );
+    }
+}

--- a/backend/tests/Telegram/Conversation/RedisTelegramConversationRepositoryTest.cs
+++ b/backend/tests/Telegram/Conversation/RedisTelegramConversationRepositoryTest.cs
@@ -1,0 +1,56 @@
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using Wallanoti.Api.Telegram.Conversation;
+
+namespace Wallanoti.Tests.Telegram.Conversation;
+
+public class RedisTelegramConversationRepositoryTest
+{
+    private readonly IDistributedCache _cache;
+    private readonly RedisTelegramConversationRepository _sut;
+
+    public RedisTelegramConversationRepositoryTest()
+    {
+        _cache = new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
+        _sut = new RedisTelegramConversationRepository(_cache);
+    }
+
+    [Fact]
+    public async Task GetStateAsync_WhenKeyNotInCache_ReturnsIdle()
+    {
+        var state = await _sut.GetStateAsync(chatId: 42L);
+
+        Assert.Equal(ConversationState.Idle, state);
+    }
+
+    [Fact]
+    public async Task SetStateAsync_StoresStateInCache()
+    {
+        await _sut.SetStateAsync(chatId: 42L, ConversationState.AwaitingUrl);
+
+        var raw = _cache.GetString("telegram:conv:42");
+        Assert.Equal(nameof(ConversationState.AwaitingUrl), raw);
+    }
+
+    [Fact]
+    public async Task GetStateAsync_WhenStateIsAwaitingUrl_ReturnsAwaitingUrl()
+    {
+        await _sut.SetStateAsync(chatId: 42L, ConversationState.AwaitingUrl);
+
+        var state = await _sut.GetStateAsync(chatId: 42L);
+
+        Assert.Equal(ConversationState.AwaitingUrl, state);
+    }
+
+    [Fact]
+    public async Task ClearAsync_RemovesStateFromCache()
+    {
+        await _sut.SetStateAsync(chatId: 42L, ConversationState.AwaitingUrl);
+
+        await _sut.ClearAsync(chatId: 42L);
+
+        var state = await _sut.GetStateAsync(chatId: 42L);
+        Assert.Equal(ConversationState.Idle, state);
+    }
+}

--- a/backend/tests/Telegram/Handlers/MessageResolver/AlertUrlTelegramMessageResolverTest.cs
+++ b/backend/tests/Telegram/Handlers/MessageResolver/AlertUrlTelegramMessageResolverTest.cs
@@ -1,0 +1,104 @@
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Telegram.Bot;
+using Telegram.Bot.Requests;
+using Telegram.Bot.Types;
+using Wallanoti.Api.Telegram.Conversation;
+using Wallanoti.Api.Telegram.Handlers.MessageResolver;
+using Wallanoti.Src.Alerts.Application.CreateAlert;
+using Wallanoti.Src.Notifications.Infrastructure.Telegram;
+
+namespace Wallanoti.Tests.Telegram.Handlers.MessageResolver;
+
+public class AlertUrlTelegramMessageResolverTest
+{
+    private readonly Mock<ITelegramBotClient> _botClientMock = new();
+    private readonly Mock<ITelegramBotConnection> _botConnectionMock = new();
+    private readonly Mock<ITelegramConversationRepository> _conversationRepoMock = new();
+    private readonly Mock<IServiceScopeFactory> _scopeFactoryMock = new();
+    private readonly Mock<IMediator> _mediatorMock = new();
+
+    private readonly AlertUrlTelegramMessageResolver _sut;
+
+    public AlertUrlTelegramMessageResolverTest()
+    {
+        _botConnectionMock.Setup(x => x.Client()).Returns(_botClientMock.Object);
+        _botClientMock
+            .Setup(x => x.SendRequest(It.IsAny<SendMessageRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Message());
+
+        var serviceProviderMock = new Mock<IServiceProvider>();
+        serviceProviderMock
+            .Setup(x => x.GetService(typeof(IMediator)))
+            .Returns(_mediatorMock.Object);
+
+        var scopeMock = new Mock<IServiceScope>();
+        scopeMock.Setup(x => x.ServiceProvider).Returns(serviceProviderMock.Object);
+
+        _scopeFactoryMock
+            .Setup(x => x.CreateScope())
+            .Returns(scopeMock.Object);
+
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<CreateAlertCommand>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(Unit.Value));
+
+        _sut = new AlertUrlTelegramMessageResolver(
+            _scopeFactoryMock.Object,
+            _botConnectionMock.Object,
+            _conversationRepoMock.Object);
+    }
+
+    [Fact]
+    public async Task Execute_WhenUrlIsNotWallapop_SendsErrorAndDoesNotChangeState()
+    {
+        const long chatId = 123L;
+        var message = new Message { Chat = new Chat { Id = chatId }, Text = "https://not-wallapop.com/search?keywords=iphone" };
+
+        await _sut.Execute(message);
+
+        _botClientMock.Verify(
+            x => x.SendRequest(It.IsAny<SendMessageRequest>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _conversationRepoMock.Verify(x => x.ClearAsync(It.IsAny<long>()), Times.Never);
+        _mediatorMock.Verify(x => x.Send(It.IsAny<CreateAlertCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Execute_WhenUrlHasNoKeywords_SendsErrorAndDoesNotChangeState()
+    {
+        const long chatId = 123L;
+        var message = new Message { Chat = new Chat { Id = chatId }, Text = "https://es.wallapop.com/search?category_id=24200" };
+
+        await _sut.Execute(message);
+
+        _botClientMock.Verify(
+            x => x.SendRequest(It.IsAny<SendMessageRequest>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _conversationRepoMock.Verify(x => x.ClearAsync(It.IsAny<long>()), Times.Never);
+        _mediatorMock.Verify(x => x.Send(It.IsAny<CreateAlertCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Execute_WithValidUrl_ExtractsKeywordsCreatesAlertAndClearsState()
+    {
+        const long chatId = 123L;
+        const string url = "https://es.wallapop.com/search?keywords=iphone+14&category_id=24200";
+        var message = new Message { Chat = new Chat { Id = chatId }, Text = url };
+
+        _conversationRepoMock
+            .Setup(x => x.ClearAsync(chatId))
+            .Returns(Task.CompletedTask);
+
+        await _sut.Execute(message);
+
+        _mediatorMock.Verify(
+            x => x.Send(
+                It.Is<CreateAlertCommand>(cmd => cmd.AlertName == "iphone 14" && cmd.UserId == chatId),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _conversationRepoMock.Verify(x => x.ClearAsync(chatId), Times.Once);
+    }
+}

--- a/backend/tests/Telegram/Handlers/MessageResolver/CancelTelegramMessageResolverTest.cs
+++ b/backend/tests/Telegram/Handlers/MessageResolver/CancelTelegramMessageResolverTest.cs
@@ -1,0 +1,67 @@
+using Moq;
+using Telegram.Bot;
+using Telegram.Bot.Requests;
+using Telegram.Bot.Types;
+using Wallanoti.Api.Telegram.Conversation;
+using Wallanoti.Api.Telegram.Handlers.MessageResolver;
+using Wallanoti.Src.Notifications.Infrastructure.Telegram;
+
+namespace Wallanoti.Tests.Telegram.Handlers.MessageResolver;
+
+public class CancelTelegramMessageResolverTest
+{
+    private readonly Mock<ITelegramBotClient> _botClientMock = new();
+    private readonly Mock<ITelegramBotConnection> _botConnectionMock = new();
+    private readonly Mock<ITelegramConversationRepository> _conversationRepoMock = new();
+
+    private readonly CancelTelegramMessageResolver _sut;
+
+    public CancelTelegramMessageResolverTest()
+    {
+        _botConnectionMock.Setup(x => x.Client()).Returns(_botClientMock.Object);
+        _botClientMock
+            .Setup(x => x.SendRequest(It.IsAny<SendMessageRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Message());
+
+        _sut = new CancelTelegramMessageResolver(_botConnectionMock.Object, _conversationRepoMock.Object);
+    }
+
+    [Fact]
+    public async Task Execute_WhenStateIsIdle_SendsNoOperationMessageAndDoesNotClear()
+    {
+        const long chatId = 123L;
+        var message = new Message { Chat = new Chat { Id = chatId }, Text = "/cancel" };
+
+        _conversationRepoMock
+            .Setup(x => x.GetStateAsync(chatId))
+            .ReturnsAsync(ConversationState.Idle);
+
+        await _sut.Execute(message);
+
+        _conversationRepoMock.Verify(x => x.ClearAsync(It.IsAny<long>()), Times.Never);
+        _botClientMock.Verify(
+            x => x.SendRequest(It.IsAny<SendMessageRequest>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Execute_WhenStateIsAwaitingUrl_ClearsStateAndSendsConfirmation()
+    {
+        const long chatId = 123L;
+        var message = new Message { Chat = new Chat { Id = chatId }, Text = "/cancel" };
+
+        _conversationRepoMock
+            .Setup(x => x.GetStateAsync(chatId))
+            .ReturnsAsync(ConversationState.AwaitingUrl);
+        _conversationRepoMock
+            .Setup(x => x.ClearAsync(chatId))
+            .Returns(Task.CompletedTask);
+
+        await _sut.Execute(message);
+
+        _conversationRepoMock.Verify(x => x.ClearAsync(chatId), Times.Once);
+        _botClientMock.Verify(
+            x => x.SendRequest(It.IsAny<SendMessageRequest>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/backend/tests/Telegram/Handlers/MessageResolver/NewAlertTelegramMessageResolverTest.cs
+++ b/backend/tests/Telegram/Handlers/MessageResolver/NewAlertTelegramMessageResolverTest.cs
@@ -1,0 +1,49 @@
+using Moq;
+using Telegram.Bot;
+using Telegram.Bot.Requests;
+using Telegram.Bot.Requests.Abstractions;
+using Telegram.Bot.Types;
+using Wallanoti.Api.Telegram.Conversation;
+using Wallanoti.Api.Telegram.Handlers.MessageResolver;
+using Wallanoti.Src.Notifications.Infrastructure.Telegram;
+
+namespace Wallanoti.Tests.Telegram.Handlers.MessageResolver;
+
+public class NewAlertTelegramMessageResolverTest
+{
+    private readonly Mock<ITelegramBotClient> _botClientMock = new();
+    private readonly Mock<ITelegramBotConnection> _botConnectionMock = new();
+    private readonly Mock<ITelegramConversationRepository> _conversationRepoMock = new();
+
+    private readonly NewAlertTelegramMessageResolver _sut;
+
+    public NewAlertTelegramMessageResolverTest()
+    {
+        _botConnectionMock.Setup(x => x.Client()).Returns(_botClientMock.Object);
+        _botClientMock
+            .Setup(x => x.SendRequest(It.IsAny<SendMessageRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Message());
+        _conversationRepoMock
+            .Setup(x => x.SetStateAsync(It.IsAny<long>(), It.IsAny<ConversationState>()))
+            .Returns(Task.CompletedTask);
+
+        _sut = new NewAlertTelegramMessageResolver(_botConnectionMock.Object, _conversationRepoMock.Object);
+    }
+
+    [Fact]
+    public async Task Execute_SetsStateToAwaitingUrlAndSendsPrompt()
+    {
+        const long chatId = 123L;
+        var message = new Message { Chat = new Chat { Id = chatId }, Text = "/alert" };
+
+        await _sut.Execute(message);
+
+        _conversationRepoMock.Verify(
+            x => x.SetStateAsync(chatId, ConversationState.AwaitingUrl),
+            Times.Once);
+
+        _botClientMock.Verify(
+            x => x.SendRequest(It.IsAny<SendMessageRequest>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/backend/tests/Telegram/Handlers/OnMessageHandlerFactoryTest.cs
+++ b/backend/tests/Telegram/Handlers/OnMessageHandlerFactoryTest.cs
@@ -1,0 +1,97 @@
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Telegram.Bot.Types;
+using Wallanoti.Api.Telegram.Conversation;
+using Wallanoti.Api.Telegram.Handlers;
+using Wallanoti.Api.Telegram.Handlers.MessageResolver;
+using Wallanoti.Src.Notifications.Infrastructure.Telegram;
+
+namespace Wallanoti.Tests.Telegram.Handlers;
+
+public class OnMessageHandlerFactoryTest
+{
+    private readonly Mock<ITelegramBotConnection> _botConnectionMock = new();
+    private readonly Mock<ITelegramConversationRepository> _conversationRepoMock = new();
+    private readonly Mock<IServiceScopeFactory> _scopeFactoryMock = new();
+
+    private readonly StartTelegramMessageResolver _startResolver;
+    private readonly NewAlertTelegramMessageResolver _newAlertResolver;
+    private readonly ListTelegramMessageResolver _listResolver;
+    private readonly AlertUrlTelegramMessageResolver _alertUrlResolver;
+    private readonly CancelTelegramMessageResolver _cancelResolver;
+
+    private readonly OnMessageHandlerFactory _sut;
+
+    public OnMessageHandlerFactoryTest()
+    {
+        _startResolver = new StartTelegramMessageResolver(_scopeFactoryMock.Object, _botConnectionMock.Object);
+        _newAlertResolver = new NewAlertTelegramMessageResolver(_botConnectionMock.Object, _conversationRepoMock.Object);
+        _listResolver = new ListTelegramMessageResolver(_scopeFactoryMock.Object, _botConnectionMock.Object);
+        _alertUrlResolver = new AlertUrlTelegramMessageResolver(_scopeFactoryMock.Object, _botConnectionMock.Object, _conversationRepoMock.Object);
+        _cancelResolver = new CancelTelegramMessageResolver(_botConnectionMock.Object, _conversationRepoMock.Object);
+
+        _sut = new OnMessageHandlerFactory(
+            _startResolver,
+            _newAlertResolver,
+            _listResolver,
+            _alertUrlResolver,
+            _cancelResolver,
+            _conversationRepoMock.Object);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenMessageIsCancel_ReturnsCancelResolver()
+    {
+        var resolver = await _sut.HandleAsync(chatId: 1L, messageText: "/cancel");
+
+        Assert.Same(_cancelResolver, resolver);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenFreeTextAndStateIsAwaitingUrl_ReturnsAlertUrlResolver()
+    {
+        _conversationRepoMock
+            .Setup(x => x.GetStateAsync(1L))
+            .ReturnsAsync(ConversationState.AwaitingUrl);
+
+        var resolver = await _sut.HandleAsync(chatId: 1L, messageText: "https://es.wallapop.com/search?keywords=iphone");
+
+        Assert.Same(_alertUrlResolver, resolver);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenFreeTextAndStateIsIdle_ReturnsStartResolver()
+    {
+        _conversationRepoMock
+            .Setup(x => x.GetStateAsync(1L))
+            .ReturnsAsync(ConversationState.Idle);
+
+        var resolver = await _sut.HandleAsync(chatId: 1L, messageText: "hello");
+
+        Assert.Same(_startResolver, resolver);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenCommandIsAlert_ReturnsNewAlertResolver()
+    {
+        var resolver = await _sut.HandleAsync(chatId: 1L, messageText: "/alert");
+
+        Assert.Same(_newAlertResolver, resolver);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenCommandIsList_ReturnsListResolver()
+    {
+        var resolver = await _sut.HandleAsync(chatId: 1L, messageText: "/list");
+
+        Assert.Same(_listResolver, resolver);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenUnknownCommand_ReturnsStartResolver()
+    {
+        var resolver = await _sut.HandleAsync(chatId: 1L, messageText: "/unknown");
+
+        Assert.Same(_startResolver, resolver);
+    }
+}

--- a/backend/tests/tests.csproj
+++ b/backend/tests/tests.csproj
@@ -26,6 +26,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\src\src.csproj" />
+      <ProjectReference Include="..\api\api.csproj" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## 🧾 Summary

Replaces the rigid one-liner `/alert, nombre, url` command with a guided two-step conversation flow. The bot now asks the user for the Wallapop search URL after `/alert`, derives the alert name automatically from the `keywords` query parameter, and saves conversation state in Redis. A `/cancel` command lets users abort at any time.

Also extracts `ITelegramBotConnection` interface to make all Telegram resolvers testable with Moq.

## 🌿 GitFlow Context

- **Source branch:** `feature/telegram-interactive-bot`
- **Target branch:** `main`
- **Release type (if applicable):** `minor`

## 🏷️ Change Type

- [x] `feat`: new feature
- [x] `refactor`: internal improvement without functional change
- [x] `test`: tests

## 🔗 Related Issue

- N/A

## 🧪 How was this tested?

1. `dotnet build` → 0 errors
2. `dotnet test backend/tests/tests.csproj` → **54/54 passed**
3. 16 new test scenarios covering:
   - `RedisTelegramConversationRepository` — get/set/clear state
   - `OnMessageHandlerFactory` — command routing and state-based routing
   - `NewAlertTelegramMessageResolver` — sets `AwaitingUrl` state
   - `CancelTelegramMessageResolver` — clears state or rejects if idle
   - `AlertUrlTelegramMessageResolver` — validates URL, extracts keywords, creates alert, clears state

## ✅ Checklist

- [x] The PR scope is clear and limited
- [x] The code follows project conventions
- [x] Tests were added/updated
- [x] No secrets, credentials, or sensitive data are included
- [x] No undocumented breaking changes are introduced

## ⚠️ Impact and Risks

- **Breaking change for existing users:** the old `/alert, nombre, url` format no longer works. Users must now send `/alert` first and then paste the URL in a second message.
- Conversation state TTL is 10 minutes (Redis). If the user doesn't reply within 10 min the state is automatically cleared.
- `TelegramBot.cs` still injects `TelegramBotConnection` (concrete) for `OnMessage`/`OnUpdate`/`Close()` since those are not on `ITelegramBotClient`.

## 🚀 Deployment

- [x] Requires Redis connection string configured (`ConnectionStrings:Redis`) — already required by existing features.
- [ ] Requires database migrations
- [ ] Requires infrastructure changes
- [ ] Requires frontend/backend coordination

## 📝 Additional Notes

- Alert name derived from `keywords` query param: `iphone+14` → `"iphone 14"` (URL-decoded, `+` → space).
- If the URL is missing `keywords`, the bot informs the user and keeps the state alive so they can retry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `/cancel` command to Telegram bot to abort ongoing operations.
  * Introduced conversation state tracking for Telegram interactions, enabling multi-step alert creation workflows.
  * Added support for creating alerts by sending Wallapop search URLs directly to the bot.

* **Refactor**
  * Improved internal abstraction layer for Telegram bot connections.

* **Tests**
  * Added comprehensive unit test coverage for new Telegram conversation and message resolver functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->