### PR TITLE
Add docs site scaffold with Astro + Starlight

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,49 @@
+name: Deploy Docs to GitHub Pages
+
+on:
+  push:
+    branches:
+      - docs/starlight
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: |
+          cd docs
+          npm ci
+
+      - name: Build site
+        run: |
+          cd docs
+          npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: docs/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v1

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,13 @@
+Wallanoti docs site powered by Astro + Starlight.
+
+To develop locally:
+
+1. cd docs
+2. npm install
+3. npm run dev
+
+Build for production:
+
+npm run build
+
+Deployment: Use GitHub Pages from `gh-pages` branch or `docs` folder.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,7 +1,8 @@
 import { defineConfig } from 'astro/config';
+import starlight from '@starlight/astro';
+
 export default defineConfig({
   site: 'https://dayronobregon.github.io/wallanoti',
-  // Integrations: if you want to enable Starlight, add it back and ensure
-  // the package is available in your registry or use a git/tarball install.
+  integrations: [starlight()],
   outDir: './dist'
 });

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,8 +1,7 @@
 import { defineConfig } from 'astro/config';
-import starlight from '@starlight/astro';
-
 export default defineConfig({
   site: 'https://dayronobregon.github.io/wallanoti',
-  integrations: [starlight()],
+  // Integrations: if you want to enable Starlight, add it back and ensure
+  // the package is available in your registry or use a git/tarball install.
   outDir: './dist'
 });

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'astro/config';
+import starlight from '@starlight/astro';
+
+export default defineConfig({
+  site: 'https://dayronobregon.github.io/wallanoti',
+  integrations: [starlight()],
+  outDir: './dist'
+});

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,6 +9,7 @@
     "preview": "astro preview"
   },
   "dependencies": {
-    "astro": "^4.3.0"
+    "astro": "^4.3.0",
+    "@starlight/astro": "latest"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "wallanoti-docs",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview"
+  },
+  "dependencies": {
+    "astro": "^4.3.0",
+    "@starlight/astro": "^0.12.0"
+  }
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,6 @@
     "preview": "astro preview"
   },
   "dependencies": {
-    "astro": "^4.3.0",
-    "@starlight/astro": "^0.12.0"
+    "astro": "^4.3.0"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
     "preview": "astro preview"
   },
   "dependencies": {
-    "astro": "^4.3.0",
+    "astro": "^3.2.0",
     "@astrojs/starlight": "^0.12.0"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,6 +10,6 @@
   },
   "dependencies": {
     "astro": "^4.3.0",
-    "@starlight/astro": "latest"
+    "@astrojs/starlight": "^0.12.0"
   }
 }

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -1,0 +1,7 @@
+import { defineCollection } from 'astro:content';
+import { docsLoader } from '@astrojs/starlight/loaders';
+import { docsSchema } from '@astrojs/starlight/schema';
+
+export const collections = {
+  docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+};

--- a/docs/src/content/docs/index.md
+++ b/docs/src/content/docs/index.md
@@ -1,0 +1,6 @@
+---
+title: Wallanoti Documentation
+description: Documentation powered by Starlight + Astro
+---
+
+Welcome to the Wallanoti docs site. This site uses the Starlight theme for Astro.

--- a/docs/src/layouts/Layout.astro
+++ b/docs/src/layouts/Layout.astro
@@ -1,0 +1,15 @@
+---
+const { children } = Astro.props;
+---
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Wallanoti Docs</title>
+  </head>
+  <body>
+    <main>
+      {children}
+    </main>
+  </body>
+</html>

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -1,0 +1,8 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout>
+  <h1>Wallanoti Documentation</h1>
+  <p>Documentation generated with Starlight + Astro.</p>
+</Layout>


### PR DESCRIPTION
Adds an initial documentation site scaffold under /docs using Astro + Starlight. Includes basic layout and index page.\n\nThis creates a dedicated worktree at worktrees/docs-starlight and the new branch docs/starlight.\n\nNext steps: run  and  to preview locally.\n\nCloses: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a hosted documentation site with a homepage and site layout.

* **Documentation**
  * Included setup, local development, build, and deployment instructions in the docs.

* **Chores**
  * Added project metadata and scripts for building/previewing the docs.
  * Added an automated workflow to build and deploy the docs to GitHub Pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->