### PR TITLE
feat(alerts): detect price drops and send differentiated notifications

### DIFF
--- a/backend/api/Extension/DependencyInjection/Infrastructure.cs
+++ b/backend/api/Extension/DependencyInjection/Infrastructure.cs
@@ -13,6 +13,7 @@ using Wallanoti.Src.Notifications.Application.SaveOnNewItemsFound;
 using Wallanoti.Src.Notifications.Domain;
 using Wallanoti.Src.Notifications.Infrastructure.Notifications;
 using Wallanoti.Src.Notifications.Infrastructure.Percistence;
+using Wallanoti.Src.Notifications.Infrastructure.Telegram;
 using Wallanoti.Src.Shared.Domain.Events;
 using Wallanoti.Src.Shared.Infrastructure.Events.MassTransit;
 using Wallanoti.Src.Shared.Infrastructure.Percistence.EntityFramework;

--- a/backend/src/Alerts/Application/SearchNewItems/ItemSearcher.cs
+++ b/backend/src/Alerts/Application/SearchNewItems/ItemSearcher.cs
@@ -6,6 +6,7 @@ using Wallanoti.Src.Alerts.Domain;
 using Wallanoti.Src.Alerts.Domain.Models;
 using Wallanoti.Src.Notifications.Domain;
 using Wallanoti.Src.Shared.Domain.Events;
+using Wallanoti.Src.Shared.Domain.ValueObjects;
 
 namespace Wallanoti.Src.Alerts.Application.SearchNewItems;
 
@@ -67,29 +68,24 @@ public sealed class ItemSearcher
                 continue;
             }
 
-            var cachedItems = GetCachedItems(alert.GetCacheKey());
+            var cachedPrices = GetCachedPrices(alert.GetCacheKey());
 
-            var newItems = (from item in wallapopItems
-                let itemCreatedAt = DateTimeOffset.FromUnixTimeMilliseconds(item.CreatedAt).DateTime
-                where itemCreatedAt.CompareTo(alert.CreatedAt) >= 0 &&
-                      !AlreadyFound(cachedItems, item.Id)
-                select item).ToList();
+            var labeledItems = ClassifyItems(wallapopItems, alert.CreatedAt, cachedPrices);
 
             var now = _timeProvider.GetUtcNow().UtcDateTime;
 
-            if (newItems.Count == 0)
+            if (labeledItems.Count == 0)
             {
                 alert.RecordSearch(now);
                 await _alertRepository.UpdateLastSearchedAt(alert.Id, alert.LastSearchedAt!.Value);
                 continue;
             }
 
-            //Añadir una nueva busqueda con los nuevos items encontrados
-            alert.NewSearch(newItems, now, now);
+            alert.NewSearch(labeledItems, now, now);
 
-            //Guardar en cache los ids de los items encontrados
+            var updatedPrices = BuildUpdatedPrices(wallapopItems, cachedPrices, labeledItems);
             await _cache.SetAsync(alert.GetCacheKey(),
-                Encoding.UTF8.GetBytes(JsonSerializer.Serialize(wallapopItems.Select(x => x.Id))));
+                Encoding.UTF8.GetBytes(JsonSerializer.Serialize(updatedPrices)));
 
             await _alertRepository.Update(alert);
 
@@ -97,15 +93,89 @@ public sealed class ItemSearcher
         }
     }
 
-    private static bool AlreadyFound(List<string> elementsInCache, string wallapopItemId)
+    private List<LabeledAlertItem> ClassifyItems(
+        List<Item> wallapopItems,
+        DateTime alertCreatedAt,
+        Dictionary<string, double> cachedPrices)
     {
-        return elementsInCache.Count != 0 && elementsInCache.Contains(wallapopItemId);
+        var labeled = new List<LabeledAlertItem>();
+
+        foreach (var item in wallapopItems)
+        {
+            var itemCreatedAt = DateTimeOffset.FromUnixTimeMilliseconds(item.CreatedAt).DateTime;
+
+            if (!cachedPrices.TryGetValue(item.Id, out var cachedPrice))
+            {
+                // Item never seen before — only include if it was created after the alert
+                if (itemCreatedAt.CompareTo(alertCreatedAt) >= 0)
+                {
+                    labeled.Add(new LabeledAlertItem(item, ItemNotificationLabel.New));
+                }
+
+                continue;
+            }
+
+            // Item already seen — check for price drop
+            var currentPrice = item.Price?.CurrentPrice;
+
+            if (currentPrice.HasValue && currentPrice.Value < cachedPrice)
+            {
+                item.Price = Price.Create(currentPrice.Value, cachedPrice);
+                labeled.Add(new LabeledAlertItem(item, ItemNotificationLabel.PriceDrop));
+            }
+
+            // Same price or price increase — skip
+        }
+
+        return labeled;
     }
 
-    private List<string> GetCachedItems(string alertId)
+    private static Dictionary<string, double> BuildUpdatedPrices(
+        List<Item> allItems,
+        Dictionary<string, double> existingCachedPrices,
+        List<LabeledAlertItem> processedItems)
     {
-        var cached = _cache.GetString(alertId);
+        // Start from current cached prices
+        var updated = new Dictionary<string, double>(existingCachedPrices);
 
-        return cached is null ? [] : JsonSerializer.Deserialize<List<string>>(cached) ?? [];
+        // Update prices for items that were processed (new or price drop)
+        foreach (var labeled in processedItems)
+        {
+            var price = labeled.Item.Price?.CurrentPrice;
+            if (price.HasValue)
+            {
+                updated[labeled.Item.Id] = price.Value;
+            }
+        }
+
+        // Also ensure ALL items from Wallapop are tracked in cache (even unchanged ones)
+        // so we can detect future price drops on them
+        foreach (var item in allItems)
+        {
+            if (!updated.ContainsKey(item.Id) && item.Price?.CurrentPrice is { } p)
+            {
+                updated[item.Id] = p;
+            }
+        }
+
+        return updated;
+    }
+
+    private Dictionary<string, double> GetCachedPrices(string cacheKey)
+    {
+        var cached = _cache.GetString(cacheKey);
+
+        if (cached is null)
+            return [];
+
+        // Try to deserialize as new schema: Dictionary<string, double>
+        try
+        {
+            return JsonSerializer.Deserialize<Dictionary<string, double>>(cached) ?? [];
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
     }
 }

--- a/backend/src/Alerts/Domain/Models/Alert.cs
+++ b/backend/src/Alerts/Domain/Models/Alert.cs
@@ -40,13 +40,13 @@ public sealed class Alert : AggregateRoot
 
     public string GetCacheKey() => Id.ToString();
 
-    public void NewSearch(List<Item>? wallapopItems, DateTime eventTimestamp, DateTime searchTimestamp)
+    public void NewSearch(List<LabeledAlertItem> labeledItems, DateTime eventTimestamp, DateTime searchTimestamp)
     {
-        if (wallapopItems is not null && wallapopItems.Count > 0)
+        if (labeledItems.Count > 0)
         {
             Record(new NewItemsFoundEvent(Guid.NewGuid().ToString(), eventTimestamp.ToString("o"), Id,
                 UserId,
-                wallapopItems));
+                labeledItems));
 
             RecordSearch(searchTimestamp);
         }

--- a/backend/src/Alerts/Domain/Models/ItemNotificationLabel.cs
+++ b/backend/src/Alerts/Domain/Models/ItemNotificationLabel.cs
@@ -1,0 +1,7 @@
+namespace Wallanoti.Src.Alerts.Domain.Models;
+
+public enum ItemNotificationLabel
+{
+    New,
+    PriceDrop
+}

--- a/backend/src/Alerts/Domain/Models/LabeledAlertItem.cs
+++ b/backend/src/Alerts/Domain/Models/LabeledAlertItem.cs
@@ -1,0 +1,13 @@
+namespace Wallanoti.Src.Alerts.Domain.Models;
+
+public sealed class LabeledAlertItem
+{
+    public Item Item { get; }
+    public ItemNotificationLabel Label { get; }
+
+    public LabeledAlertItem(Item item, ItemNotificationLabel label)
+    {
+        Item = item;
+        Label = label;
+    }
+}

--- a/backend/src/Alerts/Domain/NewItemsFoundEvent.cs
+++ b/backend/src/Alerts/Domain/NewItemsFoundEvent.cs
@@ -8,18 +8,20 @@ public sealed class NewItemsFoundEvent : DomainEvent
     public Guid AlertId { get; init; }
     public long UserId { get; init; }
     public IEnumerable<Item>? Items { get; init; }
+    public IEnumerable<LabeledAlertItem>? LabeledItems { get; init; }
 
     public NewItemsFoundEvent()
     {
-        
     }
-    
-    public NewItemsFoundEvent(string eventId, string occurredOn, Guid alertId, long userId, IEnumerable<Item>? items)
+
+    public NewItemsFoundEvent(string eventId, string occurredOn, Guid alertId, long userId,
+        IEnumerable<LabeledAlertItem> labeledItems)
         : base(eventId, occurredOn)
     {
         AlertId = alertId;
         UserId = userId;
-        Items = items;
+        LabeledItems = labeledItems;
+        Items = labeledItems.Select(x => x.Item).ToList();
     }
 
     public override string EventName() => "alert.items-found";

--- a/backend/src/Notifications/Application/SaveOnNewItemsFound/SaveNotificationOnNewItemsFound.cs
+++ b/backend/src/Notifications/Application/SaveOnNewItemsFound/SaveNotificationOnNewItemsFound.cs
@@ -1,4 +1,5 @@
 using Wallanoti.Src.Alerts.Domain;
+using Wallanoti.Src.Alerts.Domain.Models;
 using Wallanoti.Src.Notifications.Domain;
 using Wallanoti.Src.Shared.Domain.Events;
 using Wallanoti.Src.Shared.Domain.ValueObjects;
@@ -23,13 +24,16 @@ public sealed class SaveNotificationOnNewItemsFound : IDomainEventHandler<NewIte
         var notifications = new List<Notification>();
         var events = new List<DomainEvent>();
         var now = _timeProvider.GetUtcNow().UtcDateTime;
-        
-        foreach (var item in @event.Items ?? [])
+
+        foreach (var labeled in @event.LabeledItems ?? [])
         {
+            var item = labeled.Item;
+            var title = FormatTitle(item.Title, labeled.Label);
+
             var notification = Notification.Create(
                 Guid.NewGuid(),
                 @event.UserId,
-                item.Title,
+                title,
                 item.Description,
                 item.Price,
                 item.Images,
@@ -46,4 +50,10 @@ public sealed class SaveNotificationOnNewItemsFound : IDomainEventHandler<NewIte
 
         await _eventBus.Publish(events);
     }
+
+    private static string FormatTitle(string title, ItemNotificationLabel label) => label switch
+    {
+        ItemNotificationLabel.PriceDrop => $"{title} (Baja de Precio)",
+        _ => title
+    };
 }

--- a/backend/src/Notifications/Infrastructure/Telegram/TelegramPushNotificationSender.cs
+++ b/backend/src/Notifications/Infrastructure/Telegram/TelegramPushNotificationSender.cs
@@ -4,9 +4,8 @@ using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
 using Telegram.Bot.Types.ReplyMarkups;
 using Wallanoti.Src.Notifications.Domain;
-using Wallanoti.Src.Notifications.Infrastructure.Telegram;
 
-namespace Wallanoti.Src.Notifications.Infrastructure.Notifications;
+namespace Wallanoti.Src.Notifications.Infrastructure.Telegram;
 
 public class TelegramPushNotificationSender : IPushNotificationSender
 {

--- a/backend/tests/AlertCounter/2-Application/Increment/IncrementOnNewItemsFoundTest.cs
+++ b/backend/tests/AlertCounter/2-Application/Increment/IncrementOnNewItemsFoundTest.cs
@@ -22,24 +22,28 @@ public class IncrementOnNewItemsFoundTest
     public async Task Handle_WhenCounterDoesNotExist_CreatesAndSavesWithItemCount()
     {
         var alertId = Guid.NewGuid();
-        var items = new List<Item> { BuildItem("1"), BuildItem("2") };
+        var labeledItems = new List<LabeledAlertItem>
+        {
+            new(BuildItem("1"), ItemNotificationLabel.New),
+            new(BuildItem("2"), ItemNotificationLabel.New)
+        };
         var @event = new NewItemsFoundEvent(Guid.NewGuid().ToString(), DateTime.UtcNow.ToString("o"), alertId, 10,
-            items);
+            labeledItems);
 
         _repositoryMock.Setup(x => x.SearchByAlertId(alertId)).ReturnsAsync((Src.AlertCounter.Domain.AlertCounter?)null);
 
         await _sut.Handle(@event);
 
-        _repositoryMock.Verify(x => x.Save(It.Is<Src.AlertCounter.Domain.AlertCounter>(c => c.AlertId == alertId && c.Total == items.Count)),
+        _repositoryMock.Verify(x => x.Save(It.Is<Src.AlertCounter.Domain.AlertCounter>(c => c.AlertId == alertId && c.Total == labeledItems.Count)),
             Times.Once);
     }
 
     [Fact]
-    public async Task Handle_WhenItemsAreNullOrEmpty_DoesNotPersist()
+    public async Task Handle_WhenItemsAreEmpty_DoesNotPersist()
     {
         var alertId = Guid.NewGuid();
         var @event = new NewItemsFoundEvent(Guid.NewGuid().ToString(), DateTime.UtcNow.ToString("o"), alertId, 1,
-            null);
+            new List<LabeledAlertItem>());
 
         _repositoryMock.Setup(x => x.SearchByAlertId(alertId)).ReturnsAsync((Src.AlertCounter.Domain.AlertCounter?)null);
 
@@ -54,9 +58,9 @@ public class IncrementOnNewItemsFoundTest
         var alertId = Guid.NewGuid();
         var existing = Src.AlertCounter.Domain.AlertCounter.New(Guid.NewGuid(), alertId);
         existing.Increment(1);
-        var items = new List<Item> { BuildItem("new-item") };
+        var labeledItems = new List<LabeledAlertItem> { new(BuildItem("new-item"), ItemNotificationLabel.New) };
         var @event = new NewItemsFoundEvent(Guid.NewGuid().ToString(), DateTime.UtcNow.ToString("o"), alertId, 99,
-            items);
+            labeledItems);
 
         _repositoryMock.Setup(x => x.SearchByAlertId(alertId)).ReturnsAsync(existing);
 

--- a/backend/tests/Alerts/1-Domain/AlertLastSearchedAtTest.cs
+++ b/backend/tests/Alerts/1-Domain/AlertLastSearchedAtTest.cs
@@ -74,45 +74,31 @@ public class AlertLastSearchedAtTest
     }
 
     [Fact]
-    public void NewSearch_WithItems_ShouldRecordSearch()
+    public void NewSearch_WithLabeledItems_ShouldRecordSearch()
     {
         // Arrange
         var alert = Alert.Create(userId: 123, name: "Test Alert", url: "https://es.wallapop.com/search", _createdAt);
         var eventTime = _createdAt.AddMinutes(5);
         var searchTime = _createdAt.AddMinutes(5);
-        var items = new List<Item>
+        var item = new Item
         {
-            new()
-            {
-                Id = "item-1",
-                WallapopUserId = "user",
-                Title = "title",
-                WebSlug = "slug",
-                CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-                ModifiedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
-            }
+            Id = "item-1",
+            WallapopUserId = "user",
+            Title = "title",
+            WebSlug = "slug",
+            CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            ModifiedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+        };
+        var labeledItems = new List<LabeledAlertItem>
+        {
+            new(item, ItemNotificationLabel.New)
         };
 
         // Act
-        alert.NewSearch(items, eventTime, searchTime);
+        alert.NewSearch(labeledItems, eventTime, searchTime);
 
         // Assert
         Assert.NotNull(alert.LastSearchedAt);
-    }
-
-    [Fact]
-    public void NewSearch_WithNullItems_ShouldNotRecordSearch()
-    {
-        // Arrange
-        var alert = Alert.Create(userId: 123, name: "Test Alert", url: "https://es.wallapop.com/search", _createdAt);
-        var eventTime = _createdAt.AddMinutes(5);
-        var searchTime = _createdAt.AddMinutes(5);
-
-        // Act
-        alert.NewSearch(null, eventTime, searchTime);
-
-        // Assert
-        Assert.Null(alert.LastSearchedAt);
     }
 
     [Fact]
@@ -124,7 +110,7 @@ public class AlertLastSearchedAtTest
         var searchTime = _createdAt.AddMinutes(5);
 
         // Act
-        alert.NewSearch(new List<Item>(), eventTime, searchTime);
+        alert.NewSearch(new List<LabeledAlertItem>(), eventTime, searchTime);
 
         // Assert
         Assert.Null(alert.LastSearchedAt);

--- a/backend/tests/Alerts/2-Application/SearchNewItems/ItemSearcherTest.cs
+++ b/backend/tests/Alerts/2-Application/SearchNewItems/ItemSearcherTest.cs
@@ -106,20 +106,21 @@ public class ItemSearcherTest
     }
 
     [Fact]
-    public async Task Execute_SkipsItemsAlreadyInCache()
+    public async Task Execute_SkipsItemsAlreadyInCacheWithSamePrice()
     {
         var createdAt = DateTime.UtcNow;
         var alert = BuildAlert(createdAt.AddMinutes(-30), createdAt.AddMinutes(-20), createdAt.AddMinutes(-20));
         DateTime? lastSearchedAt = null;
-        var cachedId = "item-cached";
+        const string cachedId = "item-cached";
+        const double cachedPrice = 10.0;
         var items = new List<Item>
         {
-            BuildItem(cachedId, createdAt.AddMinutes(10))
+            BuildItem(cachedId, createdAt.AddMinutes(10), price: cachedPrice)
         };
 
         _alertRepositoryMock.Setup(x => x.All()).ReturnsAsync(new[] { alert });
         _wallapopRepositoryMock.Setup(x => x.Latest(alert.Url)).ReturnsAsync(items);
-        _cache.SetString(alert.GetCacheKey(), JsonSerializer.Serialize(new List<string> { cachedId }));
+        SetCacheWithPrices(alert.GetCacheKey(), new Dictionary<string, double> { [cachedId] = cachedPrice });
         _alertRepositoryMock
             .Setup(x => x.UpdateLastSearchedAt(alert.Id, It.IsAny<DateTime>()))
             .Callback<Guid, DateTime>((_, updatedAt) => lastSearchedAt = updatedAt)
@@ -133,6 +134,112 @@ public class ItemSearcherTest
         Assert.NotNull(lastSearchedAt);
         Assert.Equal(lastSearchedAt, alert.LastSearchedAt);
         Assert.NotNull(_cache.GetString(alert.GetCacheKey()));
+    }
+
+    [Fact]
+    public async Task Execute_WhenItemHasPriceDrop_PublishesEventWithPriceDropLabel()
+    {
+        var createdAt = DateTime.UtcNow.AddMinutes(-30);
+        var alert = BuildAlert(createdAt, createdAt.AddMinutes(10), createdAt.AddMinutes(10));
+        const string itemId = "item-drop";
+        const double oldPrice = 50.0;
+        const double newPrice = 35.0;
+        var itemTime = DateTime.UtcNow;
+        var items = new List<Item>
+        {
+            BuildItem(itemId, itemTime, price: newPrice)
+        };
+
+        _alertRepositoryMock.Setup(x => x.All()).ReturnsAsync(new[] { alert });
+        _wallapopRepositoryMock.Setup(x => x.Latest(alert.Url)).ReturnsAsync(items);
+        SetCacheWithPrices(alert.GetCacheKey(), new Dictionary<string, double> { [itemId] = oldPrice });
+
+        await _sut.Execute();
+
+        _eventBusMock.Verify(x => x.Publish(It.Is<List<DomainEvent>>(events =>
+            events.OfType<NewItemsFoundEvent>().Single().LabeledItems!
+                .Any(li => li.Item.Id == itemId && li.Label == ItemNotificationLabel.PriceDrop))),
+            Times.Once);
+
+        _alertRepositoryMock.Verify(x => x.Update(alert), Times.Once);
+    }
+
+    [Fact]
+    public async Task Execute_WhenItemHasPriceDrop_UpdatesCacheWithNewPrice()
+    {
+        var createdAt = DateTime.UtcNow.AddMinutes(-30);
+        var alert = BuildAlert(createdAt, createdAt.AddMinutes(10), createdAt.AddMinutes(10));
+        const string itemId = "item-drop";
+        const double oldPrice = 50.0;
+        const double newPrice = 35.0;
+        var itemTime = DateTime.UtcNow;
+        var items = new List<Item>
+        {
+            BuildItem(itemId, itemTime, price: newPrice)
+        };
+
+        _alertRepositoryMock.Setup(x => x.All()).ReturnsAsync(new[] { alert });
+        _wallapopRepositoryMock.Setup(x => x.Latest(alert.Url)).ReturnsAsync(items);
+        SetCacheWithPrices(alert.GetCacheKey(), new Dictionary<string, double> { [itemId] = oldPrice });
+
+        await _sut.Execute();
+
+        var cachedRaw = _cache.GetString(alert.GetCacheKey());
+        Assert.NotNull(cachedRaw);
+        var cached = JsonSerializer.Deserialize<Dictionary<string, double>>(cachedRaw!);
+        Assert.NotNull(cached);
+        Assert.Equal(newPrice, cached![itemId]);
+    }
+
+    [Fact]
+    public async Task Execute_WhenItemHasPriceDrop_ItemCarriesPreviousPriceInEvent()
+    {
+        var createdAt = DateTime.UtcNow.AddMinutes(-30);
+        var alert = BuildAlert(createdAt, createdAt.AddMinutes(10), createdAt.AddMinutes(10));
+        const string itemId = "item-drop";
+        const double oldPrice = 50.0;
+        const double newPrice = 35.0;
+        var itemTime = DateTime.UtcNow;
+        var items = new List<Item>
+        {
+            BuildItem(itemId, itemTime, price: newPrice)
+        };
+
+        _alertRepositoryMock.Setup(x => x.All()).ReturnsAsync(new[] { alert });
+        _wallapopRepositoryMock.Setup(x => x.Latest(alert.Url)).ReturnsAsync(items);
+        SetCacheWithPrices(alert.GetCacheKey(), new Dictionary<string, double> { [itemId] = oldPrice });
+
+        await _sut.Execute();
+
+        _eventBusMock.Verify(x => x.Publish(It.Is<List<DomainEvent>>(events =>
+            events.OfType<NewItemsFoundEvent>().Single().LabeledItems!
+                .Any(li =>
+                    li.Item.Id == itemId &&
+                    li.Item.Price!.PreviousPrice == oldPrice &&
+                    li.Item.Price.CurrentPrice == newPrice))),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Execute_NewItemsLabeledAsNew_InLabeledItems()
+    {
+        var alert = BuildAlert(DateTime.UtcNow.AddMinutes(-30), DateTime.UtcNow.AddMinutes(-20), DateTime.UtcNow.AddMinutes(-20));
+        var newerTime = DateTime.UtcNow;
+        var items = new List<Item>
+        {
+            BuildItem("new-item-1", newerTime),
+            BuildItem("new-item-2", newerTime.AddMinutes(1))
+        };
+
+        _alertRepositoryMock.Setup(x => x.All()).ReturnsAsync(new[] { alert });
+        _wallapopRepositoryMock.Setup(x => x.Latest(alert.Url)).ReturnsAsync(items);
+
+        await _sut.Execute();
+
+        _eventBusMock.Verify(x => x.Publish(It.Is<List<DomainEvent>>(events =>
+            events.OfType<NewItemsFoundEvent>().Single().LabeledItems!
+                .All(li => li.Label == ItemNotificationLabel.New))),
+            Times.Once);
     }
 
     [Fact]
@@ -154,13 +261,18 @@ public class ItemSearcherTest
             Times.Once);
     }
 
+    private void SetCacheWithPrices(string cacheKey, Dictionary<string, double> prices)
+    {
+        _cache.SetString(cacheKey, JsonSerializer.Serialize(prices));
+    }
+
     private static Alert BuildAlert(DateTime createdAt, DateTime? updatedAt = null, DateTime? lastSearchedAt = null, bool isActive = true)
     {
         return new Alert(Guid.NewGuid(), 1, "alert", "https://es.wallapop.com/item/slug", createdAt, updatedAt,
             isActive, lastSearchedAt);
     }
 
-    private static Item BuildItem(string id, DateTime createdAt, DateTime? modifiedAt = null)
+    private static Item BuildItem(string id, DateTime createdAt, DateTime? modifiedAt = null, double price = 10.0)
     {
         return new Item
         {
@@ -169,7 +281,7 @@ public class ItemSearcherTest
             Title = "title",
             Description = "desc",
             CategoryId = 1,
-            Price = Price.Create(10, null),
+            Price = Price.Create(price, null),
             Images = new List<string>(),
             Location = Location.Create("city", "region"),
             Shipping = false,

--- a/backend/tests/Notifications/2-Application/SaveOnNewItemsFound/SaveNotificationOnNewItemsFoundTest.cs
+++ b/backend/tests/Notifications/2-Application/SaveOnNewItemsFound/SaveNotificationOnNewItemsFoundTest.cs
@@ -25,25 +25,75 @@ public class SaveNotificationOnNewItemsFoundTest
     }
 
     [Fact]
-    public async Task Handle_WithItems_ShouldPersistNotificationsAndPublishEvents()
+    public async Task Handle_WithNewItems_ShouldPersistNotificationsAndPublishEvents()
     {
-        var items = new List<Item> { BuildItem("one"), BuildItem("two") };
-        var @event = new NewItemsFoundEvent(Guid.NewGuid().ToString(), DateTime.UtcNow.ToString("o"), Guid.NewGuid(), 7,
-            items);
+        var labeledItems = new List<LabeledAlertItem>
+        {
+            new(BuildItem("one"), ItemNotificationLabel.New),
+            new(BuildItem("two"), ItemNotificationLabel.New)
+        };
+        var @event = BuildEvent(labeledItems);
 
         await _sut.Handle(@event);
 
-        _repositoryMock.Verify(x => x.AddRangeAsync(It.Is<IEnumerable<Notification>>(n => n.Count() == items.Count)),
+        _repositoryMock.Verify(x => x.AddRangeAsync(It.Is<IEnumerable<Notification>>(n => n.Count() == labeledItems.Count)),
             Times.Once);
         _eventBusMock.Verify(x => x.Publish(It.Is<List<DomainEvent>>(events =>
-            events.Count == items.Count && events.All(e => e is NotificationCreatedEvent))), Times.Once);
+            events.Count == labeledItems.Count && events.All(e => e is NotificationCreatedEvent))), Times.Once);
     }
 
     [Fact]
-    public async Task Handle_WithoutItems_DoesNothing()
+    public async Task Handle_WithPriceDropItem_ShouldIncludeLabelInTitle()
     {
-        var @event = new NewItemsFoundEvent(Guid.NewGuid().ToString(), DateTime.UtcNow.ToString("o"), Guid.NewGuid(), 7,
-            null);
+        const string originalTitle = "Bicicleta de montaña";
+        var item = BuildItem("drop", title: originalTitle);
+        var labeledItems = new List<LabeledAlertItem>
+        {
+            new(item, ItemNotificationLabel.PriceDrop)
+        };
+        var @event = BuildEvent(labeledItems);
+
+        List<Notification>? savedNotifications = null;
+        _repositoryMock
+            .Setup(x => x.AddRangeAsync(It.IsAny<IEnumerable<Notification>>()))
+            .Callback<IEnumerable<Notification>>(notifications => savedNotifications = notifications.ToList())
+            .Returns(Task.CompletedTask);
+
+        await _sut.Handle(@event);
+
+        Assert.NotNull(savedNotifications);
+        Assert.Single(savedNotifications!);
+        Assert.Equal($"{originalTitle} (Baja de Precio)", savedNotifications![0].Title);
+    }
+
+    [Fact]
+    public async Task Handle_WithNewItem_ShouldUseOriginalTitle()
+    {
+        const string originalTitle = "Bicicleta de montaña";
+        var item = BuildItem("new-one", title: originalTitle);
+        var labeledItems = new List<LabeledAlertItem>
+        {
+            new(item, ItemNotificationLabel.New)
+        };
+        var @event = BuildEvent(labeledItems);
+
+        List<Notification>? savedNotifications = null;
+        _repositoryMock
+            .Setup(x => x.AddRangeAsync(It.IsAny<IEnumerable<Notification>>()))
+            .Callback<IEnumerable<Notification>>(notifications => savedNotifications = notifications.ToList())
+            .Returns(Task.CompletedTask);
+
+        await _sut.Handle(@event);
+
+        Assert.NotNull(savedNotifications);
+        Assert.Single(savedNotifications!);
+        Assert.Equal(originalTitle, savedNotifications![0].Title);
+    }
+
+    [Fact]
+    public async Task Handle_WithoutLabeledItems_DoesNotPersistOrPublish()
+    {
+        var @event = BuildEvent([]);
 
         await _sut.Handle(@event);
 
@@ -51,13 +101,19 @@ public class SaveNotificationOnNewItemsFoundTest
         _eventBusMock.Verify(x => x.Publish(It.Is<List<DomainEvent>>(events => events.Count == 0)), Times.Once);
     }
 
-    private static Item BuildItem(string slug)
+    private static NewItemsFoundEvent BuildEvent(List<LabeledAlertItem> labeledItems)
+    {
+        return new NewItemsFoundEvent(Guid.NewGuid().ToString(), DateTime.UtcNow.ToString("o"), Guid.NewGuid(), 7,
+            labeledItems);
+    }
+
+    private static Item BuildItem(string slug, string? title = null)
     {
         return new Item
         {
             Id = Guid.NewGuid().ToString(),
             WallapopUserId = "user",
-            Title = $"item-{slug}",
+            Title = title ?? $"item-{slug}",
             Description = "desc",
             CategoryId = 1,
             Price = Price.Create(20, 25),


### PR DESCRIPTION
## 🧾 Summary

Adds price-drop detection to the Wallapop item search flow. When a known item reappears at a lower price, it is classified as a `PriceDrop` and a notification is sent with the title suffix **(Baja de Precio)**. Items already seen at the same or higher price are silently ignored, eliminating duplicate notifications.

Key changes:
- **`ItemNotificationLabel`** (new enum): `New` | `PriceDrop`
- **`LabeledAlertItem`** (new class): wraps `Item` + its label
- **`ItemSearcher`**: cache schema changed from `List<string>` (IDs only) to `Dictionary<string, double>` (ID → current price); `ClassifyItems` handles all three cases (new / price-drop / unchanged)
- **`NewItemsFoundEvent`**: accepts `IEnumerable<LabeledAlertItem>`; derives `Items` for backward compatibility
- **`Alert.NewSearch`**: updated signature to accept `List<LabeledAlertItem>`
- **`SaveNotificationOnNewItemsFound`**: formats title with "(Baja de Precio)" when label is `PriceDrop`
- All affected tests updated; 107 tests passing

## 🌿 GitFlow Context

- **Source branch:** `feat/price-drop-detection`
- **Target branch:** `main`
- **Release type:** `minor`

## 🏷️ Change Type

- [x] `feat`: new feature
- [x] `refactor`: internal improvement without functional change
- [x] `test`: tests

## 🔗 Related Issue

- Related to #

## 🧪 How was this tested?

1. `cd backend && dotnet test` — all 107 tests pass (0 failures)
2. New unit tests cover: new item classification, price-drop classification, same-price skip, cache update after price drop, previous price propagation in event, title formatting with label

## ✅ Checklist

- [x] The PR scope is clear and limited
- [x] The code follows project conventions
- [x] Tests were added/updated (or justification provided if not applicable)
- [x] Relevant documentation was updated (if applicable)
- [x] No secrets, credentials, or sensitive data are included
- [x] No undocumented breaking changes are introduced

## ⚠️ Impact and Risks

- **Breaking change (internal)**: `NewItemsFoundEvent` constructor no longer accepts `IEnumerable<Item>` — only `IEnumerable<LabeledAlertItem>`. All consumers in this codebase have been updated. No external consumers known.
- **Cache schema migration**: Existing Redis cache entries use the old `List<string>` schema. On first run after deploy, `GetCachedPrices` will fail to deserialize them and return an empty dictionary — items will be re-classified as new and re-notified once. This is safe and self-healing.
- `IncrementOnNewItemsFound` uses `@event.Items` (derived from `LabeledItems`) — no change in behavior.

## 🚀 Deployment

- [x] No additional actions required

> **Note:** Redis cache entries from the old schema will be silently dropped on first read and rebuilt automatically. No manual cache flush required.

## 📝 Additional Notes

The `PreviousPrice` is injected directly into `Item.Price` before creating the `LabeledAlertItem` (since `Item` is a `sealed class` with mutable setters, not a record). This allows downstream consumers (e.g. `Notification.FormattedString()`) to display the price change without any additional changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Alerts now detect when prices drop on monitored items and send dedicated notifications.
  * Price drop notifications are formatted distinctly from new item alerts to help you identify savings opportunities.

* **Improvements**
  * Enhanced price tracking system for improved accuracy in monitoring item price changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->